### PR TITLE
Make the Action configure the git safe.directory globally

### DIFF
--- a/.cloudbees/workflows/workflow.yml
+++ b/.cloudbees/workflows/workflow.yml
@@ -8,15 +8,21 @@ on:
       - "*"
 
 jobs:
-  
+
   build:
     steps:
-      - uses: .
+      - name: Git checkout
+        uses: docker://alpine/git:2.43.0
+        run: |
+          set -x
+          git config --global --add safe.directory `pwd`
+          git clone ${{ cloudbees.scm.repositoryUrl }} .
+          git checkout ${{ cloudbees.scm.sha }}
       - id: test
-        name: Build and test
+        name: Run unit tests
         uses: docker://golang:1.21
         run: |
-          go test ./...
+          go test --cover ./...
       - id: dockerconfig
         name: Configure container registry credentials
         uses: cloudbees-io/configure-oci-credentials@v0
@@ -29,4 +35,18 @@ jobs:
         uses: cloudbees-io/kaniko@v1
         with:
           dockerfile: Dockerfile
-          destination: ${{ cloudbees.scm.branch == 'main' && format('{0}/staging/cloudbees-io-checkout:v1.0.8', vars.STAGING_DOCKER_REGISTRY) || format('{0}/staging/cloudbees-io-checkout:{1}', vars.STAGING_DOCKER_REGISTRY, cloudbees.version) }}
+          destination: ${{ cloudbees.scm.branch == 'main' && format('{0}/staging/cloudbees-io-checkout:v1.0.8', vars.STAGING_DOCKER_REGISTRY) || format('{0}/staging/cloudbees-io-checkout:{1},{0}/staging/cloudbees-io-checkout:{2}', vars.STAGING_DOCKER_REGISTRY, cloudbees.version, cloudbees.scm.sha) }}
+
+  test:
+    needs: build
+    steps:
+      - name: Run Action
+        uses: ./
+      - name: Verify that the repo was checked out
+        uses: docker://golang:1.20.5-alpine3.18
+        run: |
+          set -x
+          [ -d .git ]
+          [ -f Dockerfile ]
+          go build .
+

--- a/.cloudbees/workflows/workflow.yml
+++ b/.cloudbees/workflows/workflow.yml
@@ -35,7 +35,7 @@ jobs:
         uses: cloudbees-io/kaniko@v1
         with:
           dockerfile: Dockerfile
-          destination: ${{ cloudbees.scm.branch == 'main' && format('{0}/staging/cloudbees-io-checkout:v1.0.8', vars.STAGING_DOCKER_REGISTRY) || format('{0}/staging/cloudbees-io-checkout:{1},{0}/staging/cloudbees-io-checkout:{2}', vars.STAGING_DOCKER_REGISTRY, cloudbees.version, cloudbees.scm.sha) }}
+          destination: ${{ cloudbees.scm.branch == 'main' && format('{0}/staging/cloudbees-io-checkout:v1.0.9', vars.STAGING_DOCKER_REGISTRY) || format('{0}/staging/cloudbees-io-checkout:{1},{0}/staging/cloudbees-io-checkout:{2}', vars.STAGING_DOCKER_REGISTRY, cloudbees.version, cloudbees.scm.sha) }}
 
   test:
     needs: build

--- a/.cloudbees/workflows/workflow.yml
+++ b/.cloudbees/workflows/workflow.yml
@@ -25,7 +25,7 @@ jobs:
           go test --cover ./...
       - id: dockerconfig
         name: Configure container registry credentials
-        uses: cloudbees-io/configure-oci-credentials@v0
+        uses: cloudbees-io/configure-oci-credentials@v1
         with:
           registry: ${{ vars.STAGING_DOCKER_REGISTRY }}
           username: ${{ secrets.STAGING_DOCKER_USERNAME }}

--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,9 @@ runs:
   using: composite
   steps:
     - name: Checkout
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/cloudbees-io-checkout:v1.0.8
+      #uses: docker://public.ecr.aws/l7o7z1g8/actions/cloudbees-io-checkout:v1.0.8
+      # TODO: use interpolated tag once we aligned on the release process
+      uses: docker://registry.saas-dev.beescloud.com/staging/cloudbees-io-checkout:${{ action.scm.sha }}
       env:
         CLOUDBEES_EVENT_PATH: /cloudbees/event.json
       shell: sh

--- a/action.yml
+++ b/action.yml
@@ -88,9 +88,9 @@ runs:
   using: composite
   steps:
     - name: Checkout
-      #uses: docker://public.ecr.aws/l7o7z1g8/actions/cloudbees-io-checkout:v1.0.8
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/cloudbees-io-checkout:v1.0.8
       # TODO: use interpolated tag once we aligned on the release process
-      uses: docker://registry.saas-dev.beescloud.com/staging/cloudbees-io-checkout:${{ action.scm.sha }}
+      #uses: docker://registry.saas-dev.beescloud.com/staging/cloudbees-io-checkout:${{ action.scm.sha }}
       env:
         CLOUDBEES_EVENT_PATH: /cloudbees/event.json
       shell: sh

--- a/internal/checkout/source_provider.go
+++ b/internal/checkout/source_provider.go
@@ -294,14 +294,6 @@ func (cfg *Config) Run(ctx context.Context) (retErr error) {
 	}
 	cli.SetEnv("RUNNER_TEMP", temp)
 
-	tempHome := filepath.Join(temp, uniqueID)
-	if err := os.MkdirAll(tempHome, os.ModePerm); err != nil {
-		return err
-	}
-
-	fmt.Printf("Temporarily overriding HOME='%s' before making global git config changes\n", tempHome)
-	cli.SetEnv("HOME", tempHome)
-
 	if cfg.SetSafeDirectory {
 		fmt.Println("Adding Repository directory to the temporary git global config as a safe directory")
 		if err := cli.AddConfigStr(true, "safe.directory", workspacePath); err != nil {


### PR DESCRIPTION
This is to avoid having to run `git config --global --add safe.directory /cloudbees/workspace` explicitly within workflows after checking out a git repo.
(git requires the safe.directory to be configured explicitly when the workspace directory may be owned by a different user than the current git process which is the case when different containerized job steps are run with different UIDs.)

Also, the PR adjusts the workflow to allow testing the Action within a pull request build.