### PR TITLE
update required params

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -19,12 +19,12 @@ The CloudBees API token is used to fetch an app access token if neither the PAT 
 
 | `provider`
 | String
-| Yes
+| No
 | SCM provider hosting the repository, such as GitHub, Bitbucket, or GitLab.
 
 | `repository`
 | String
-| Yes
+| No
 | Repository name with owner, for example, `actions/checkout`.
 
 | `ref`


### PR DESCRIPTION
provider, repository are not required params
```
  provider:
    description: 'SCM provider that is hosting the repository. For example github, bitbucket, gitlab or custom'
    default: "${{ cloudbees.scm.provider }}"
  repository:
    description: 'Repository name with owner. For example, actions/checkout. Alternatively if provider is custom then this is the clone URL of the repository'
    default: "${{ cloudbees.scm.repository }}"
```