### PR TITLE
CBP-10833 - Output the commit ID from the checkout action

### DIFF
--- a/.cloudbees/testing/action.yml
+++ b/.cloudbees/testing/action.yml
@@ -87,10 +87,25 @@ inputs:
   gitlab-server-url:
     description: The base URL for the GitLab instance that you are trying to clone from, will use environment defaults (i.e. the GITLAB_SERVER_URL environment variable) to fetch from the same instance that the workflow is running from unless specified. Example URLs are https://gitlab.com or https://my-gl-server.example.com
     required: false
+
+outputs:
+  repository-url:
+    value: ${{ steps.checkout.outputs.repository-url }}
+    description: "The clone URL of the repository"
+  commit:
+    value: ${{ steps.checkout.outputs.commit }}
+    description: "Commit ID from source repository"
+  commit-url:
+    value: ${{ steps.checkout.outputs.commit-url }}
+    description: "Commit URL from source repository"
+  ref:
+    value: ${{ steps.checkout.outputs.ref }}
+    description: "Ref or branch of the checked-out repository"
 runs:
   using: composite
   steps:
     - name: Checkout
+      id: checkout
       uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/cloudbees-io-checkout:${{ action.scm.sha }}
       env:
         CLOUDBEES_EVENT_PATH: /cloudbees/event.json

--- a/.cloudbees/workflows/workflow.yml
+++ b/.cloudbees/workflows/workflow.yml
@@ -44,6 +44,7 @@ jobs:
     needs: build
     steps:
       - name: Run Action
+        id: runaction
         uses: ./.cloudbees/testing
         env:
           RUNNER_DEBUG: "1"
@@ -54,3 +55,7 @@ jobs:
           [ -d .git ]
           [ -f Dockerfile ]
           go build .
+          echo Repository URL = ${{ steps.runaction.outputs.repository-url }}
+          echo Commit ID = ${{ steps.runaction.outputs.commit }}
+          echo Commit URL = ${{ steps.runaction.outputs.commit-url }}
+          echo Ref = ${{ steps.runaction.outputs.ref }}

--- a/README.adoc
+++ b/README.adoc
@@ -118,8 +118,36 @@ Example URLs are `\https://bitbucket.org` or `\https://my-bbdc-server.example.co
 | The base URL for the GitLab instance that you are cloning from.
 Unless specified, the base URL uses environment defaults to fetch from the same instance the workflow is running from.
 Example URLs are `\https://gitlab.com` or `\https://my-gl-server.example.com`.
+
 |===
 
+== Outputs
+
+[cols="2a,1a,3a",options="header"]
+.Output details
+|===
+
+| Input name
+| Data type
+| Description
+
+| `repository-url`
+| String
+| The clone URL of the repository.
+
+| `commit`
+| String
+| The commit ID from the source repository.
+
+| `commit-url`
+| String
+| The commit URL from the source repository. This may be 'Unavailable' if the commit is a local merge commit.
+
+| `ref`
+| String
+| The ref or branch of the checked-out repository. This may be empty if in a detached-head state or if the commit is a local merge commit.
+
+|===
 == Usage example
 
 In the YAML file, all values are required, unless otherwise noted. Default values are included in the example YAML file below. Refer to the notes for options and details.
@@ -138,6 +166,7 @@ In your YAML file, add:
 ----
       - name: Check out repo
         uses: cloudbees-io/checkout@v1
+        id: checkout
         with:
           provider: ${{ cloudbees.scm.provider }}
           repository: ${{ cloudbees.repository }}
@@ -156,6 +185,14 @@ In your YAML file, add:
           github-server-url: ''
           bitbucket-server-url: ''
           gitlab-server-url: ''
+      - name: Display outputs
+        uses: docker://golang:1.20.3-alpine3.17
+        shell: sh
+        run: |
+          echo Repository URL = ${{ steps.checkout.outputs.repository-url }}
+          echo Commit ID = ${{ steps.checkout.outputs.commit }}
+          echo Commit URL = ${{ steps.checkout.outputs.commit-url }}
+          echo Ref = ${{ steps.checkout.outputs.ref }}
 ----
 
 == License

--- a/action.yml
+++ b/action.yml
@@ -87,10 +87,25 @@ inputs:
   gitlab-server-url:
     description: The base URL for the GitLab instance that you are trying to clone from, will use environment defaults (i.e. the GITLAB_SERVER_URL environment variable) to fetch from the same instance that the workflow is running from unless specified. Example URLs are https://gitlab.com or https://my-gl-server.example.com
     required: false
+
+outputs:
+  repository-url:
+    value: ${{ steps.checkout.outputs.repository-url }}
+    description: "The clone URL of the repository"
+  commit:
+    value: ${{ steps.checkout.outputs.commit }}
+    description: "The commit ID from the source repository"
+  commit-url:
+    value: ${{ steps.checkout.outputs.commit-url }}
+    description: "The commit URL from the source repository"
+  ref:
+    value: ${{ steps.checkout.outputs.ref }}
+    description: "The ref or branch of the checked-out repository"
 runs:
   using: composite
   steps:
     - name: Checkout
+      id: checkout
       uses: docker://public.ecr.aws/l7o7z1g8/actions/cloudbees-io-checkout:${{ action.scm.sha }}
       env:
         CLOUDBEES_EVENT_PATH: /cloudbees/event.json

--- a/internal/git/cli.go
+++ b/internal/git/cli.go
@@ -240,6 +240,24 @@ func (g *GitCLI) TagExists(pattern string) (bool, error) {
 	return strings.TrimSpace(output) != "", nil
 }
 
+func (g *GitCLI) GetLastCommitId() (string, error) {
+	output, err := g.runOutput("log", "-1", "--format=%H")
+	if err != nil {
+		return "", err
+	}
+	core.Debug("GetLastCommitId returns %s", output)
+	return output, nil
+}
+
+func (g *GitCLI) GetCurrentBranch() (string, error) {
+	output, err := g.runOutput("branch", "--show-current")
+	if err != nil {
+		return "", err
+	}
+	core.Debug("GetCurrentBranch returns %s", output)
+	return output, nil
+}
+
 func (g *GitCLI) BranchGetDefault(repositoryUrl string) (string, error) {
 	output, err := g.runOutput("ls-remote", "--quiet", "--exit-code", "--symref", repositoryUrl, "HEAD")
 	if err != nil {


### PR DESCRIPTION
See https://cloudbees.atlassian.net/browse/CBP-10833

**Outputs**:

**repository-url**: The input repository URL
**commit**: The input commit id or if not supplied, the last commit id provided by git log -1 --format=%H
If it is a local merge commit, this is set to empty.
**commit-url:** A direct link to the commit URL which depends on provider:
If it is a local merge commit (or commit id is empty)  this is set to "Unavailable"
```
GitHub & GitLab:
	commit_url = <repo url> + "/commit/" + commit_id
Bitbucket:
	fullCommitUrl = <repo url>  + "/commits/" + commit_id
BitbucketDatacenter:
	fullCommitUrl = <bitbucket data center server url> + "projects/" + <project name> + "/repos/" + <repo name> + "/commits/" + commit_id
```

**ref**: Either the generated ref (branch or tag) or if empty, the branch provided by 'git branch --show-current' 

Notes: 

1. GitLab is not currently supported by CBP integration but can be used in an action.
2. repository_url will default to the workflow’s repo if not specified in the checkout action.
3. Merge commits for bitbucket and gitlab will return an empty commit_ID and "Unavailable" as the commit URL because the commit is local and temporary and cannot be globally accessed after the fact.

TDD: https://docs.google.com/document/d/1I1w57aimFhGiP28AGO1olGFbfIXNfQ4Xd_4O_qc7oSs/edit?tab=t.0#heading=h.eqbj76dbnog2

Test matrix: https://docs.google.com/spreadsheets/d/1b7hWj_IYAkH7HIwDWsS0UIRX5CDp9yjGPv2RW7Cdk04/edit?gid=0#gid=0

