### PR TITLE
CBP-Many_Tickets: Upgrade GoLang to 1.26.0

### DIFF
--- a/.cloudbees/workflows/workflow.yml
+++ b/.cloudbees/workflows/workflow.yml
@@ -22,7 +22,7 @@ jobs:
         uses: https://github.com/cloudbees-io/checkout@v1
 
       - name: Run unit tests and verify coding rules
-        uses: docker://golang:1.25.4
+        uses: docker://golang:1.26.0
         run: |
           make verify
 
@@ -62,7 +62,7 @@ jobs:
         env:
           RUNNER_DEBUG: "1"
       - name: Verify that the repo was checked out
-        uses: docker://golang:1.25.4
+        uses: docker://golang:1.26.0
         run: |
           set -x
           [ -d .git ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #syntax=docker/dockerfile:1
-FROM golang:1.25.4-alpine3.22 AS build
+FROM golang:1.26.0-alpine3.22 AS build
 
 WORKDIR /work
 


### PR DESCRIPTION
CBP-Many_Tickets: Upgrade GoLang Version to Latest, Which is 1.26.0 Right Now.

For Runs Failed or Passed, For Action, Ignore GitHub ✅ or ❌ , Check Links From PreProd Only, All Workflow Team Actions Maintained in PreProd and All Needed Steps Get Executed in PreProd As Discussed in Slack Workflow Channel.