### PR TITLE
CBP-32994: Security Version Upgrade

### DIFF
--- a/.cloudbees/workflows/workflow.yml
+++ b/.cloudbees/workflows/workflow.yml
@@ -22,7 +22,7 @@ jobs:
         uses: https://github.com/cloudbees-io/checkout@v1
 
       - name: Run unit tests and verify coding rules
-        uses: docker://golang:1.25.4
+        uses: docker://golang:1.26.0
         run: |
           make verify
 
@@ -62,7 +62,7 @@ jobs:
         env:
           RUNNER_DEBUG: "1"
       - name: Verify that the repo was checked out
-        uses: docker://golang:1.25.4
+        uses: docker://golang:1.26.0
         run: |
           set -x
           [ -d .git ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #syntax=docker/dockerfile:1
-FROM golang:1.25.4-alpine3.22 AS build
+FROM golang:1.26.0-alpine3.22 AS build
 
 WORKDIR /work
 

--- a/README.adoc
+++ b/README.adoc
@@ -172,4 +172,4 @@ link:https://opensource.org/license/mit/[MIT license].
 == References
 
 * Learn more about link:https://docs.cloudbees.com/docs/cloudbees-saas-platform-actions/latest/[using actions in CloudBees workflows].
-* Learn about link:https://docs.cloudbees.com/docs/cloudbees-saas-platform/latest/[the CloudBees platform].
+* Learn about link:https://docs.cloudbees.com/docs/cloudbees-saas-platform/latest/[the CloudBees platform]. 


### PR DESCRIPTION
CBP-32994: Upgrade GoLang Version to Latest, Which is 1.26.0 Right Now and Above 1.25.7, Fixes CVE As Per Ticket.

For Runs Failed or Passed, For Action, Ignore GitHub ✅ or ❌ , Check Links From PreProd Only, All Workflow Team Actions Maintained in PreProd and All Needed Steps Get Executed in PreProd As Discussed in Slack Workflow Channel.

PreProd Run [Link](https://saas-preprod.beescloud.com/cloudbees-preprod/2c952b88-f84c-4e1e-58cf-d46486aab4bc/components/3c311ade-f180-4a81-ad3f-a9fcaaf7624c/runs/c7b4dfe7-bd26-406d-8cbe-dc3b9df9184a/b41d1185-5015-4c8b-adb3-ebb4f6aa496e/1/logs?componentId=3c311ade-f180-4a81-ad3f-a9fcaaf7624c&workflowId=c7b4dfe7-bd26-406d-8cbe-dc3b9df9184a&organizationId=2c952b88-f84c-4e1e-58cf-d46486aab4bc&job=test-simple-origin-repo-specified)