### PR TITLE
[CBP-45084] Migrate kaniko build to cb-internal-shared-actions/build@v8

### DIFF
--- a/.cloudbees/testing/action.yml
+++ b/.cloudbees/testing/action.yml
@@ -81,7 +81,7 @@ runs:
   steps:
     - name: Checkout
       id: checkout
-      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/cloudbees-io-checkout:${{ cloudbees.version }}
+      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/cloudbees-io-checkout:preprod
       env:
         CLOUDBEES_EVENT_PATH: /cloudbees/event.json
       shell: sh

--- a/.cloudbees/testing/action.yml
+++ b/.cloudbees/testing/action.yml
@@ -81,7 +81,7 @@ runs:
   steps:
     - name: Checkout
       id: checkout
-      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/cloudbees-io-checkout:${{ action.scm.sha }}
+      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/cloudbees-io-checkout:${{ cloudbees.version }}
       env:
         CLOUDBEES_EVENT_PATH: /cloudbees/event.json
       shell: sh

--- a/.cloudbees/workflows/workflow.yml
+++ b/.cloudbees/workflows/workflow.yml
@@ -17,6 +17,7 @@ jobs:
     if: cloudbees.api.url == 'https://api.saas-preprod.beescloud.com' || cloudbees.api.url == 'https://api.cloudbees.io'
     permissions:
       scm-token-own: read
+      scm-token-org: read
       id-token: write
     steps:
       - name: Git checkout

--- a/.cloudbees/workflows/workflow.yml
+++ b/.cloudbees/workflows/workflow.yml
@@ -27,31 +27,18 @@ jobs:
         run: |
           make verify
 
-      - name: Login to AWS
-        uses: https://github.com/cloudbees-io/configure-aws-credentials@v1
+      - id: build
+        name: Build, scan and push to ECR
+        uses: calculi-corp/cb-internal-shared-actions/build@v8
         with:
-          aws-region: us-east-1
-          role-to-assume: ${{ vars.oidc_staging_iam_role }}
-          role-duration-seconds: "3600"
-
-      - name: Configure container registry for Staging ECR
-        uses: https://github.com/cloudbees-io/configure-ecr-credentials@v1
-
-      - name: Build image
-        id: build
-        uses: https://github.com/cloudbees-io/kaniko@v1
-        with:
-          destination: 020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/cloudbees-io-checkout:${{ cloudbees.scm.sha }}${{ cloudbees.scm.branch == 'main' && ',020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/cloudbees-io-checkout:latest' || ''}}
-          labels: maintainer=sdp-pod-3,email=engineering@cloudbees.io
-
-      - id: slsa-attestation
-        name: Generate SLSA attestation
-        uses: calculi-corp/slsa-attestation@v1
-        with:
-          image-digest: 020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/cloudbees-io-checkout@${{ steps.build.outputs.digest }}
-          aws-role-to-assume: ${{ vars.oidc_staging_iam_role }}
-          aws-region: us-east-1
-          aws-kms-alias: cbp-dev-kms-key-cosign          
+          go-binary-build: "true"
+          go-binary-name: checkout
+          kaniko-build: "true"
+          run-unit-test: "false"
+          registry-url: 020229604682.dkr.ecr.us-east-1.amazonaws.com
+          registry-image-name: actions/cloudbees-io-checkout
+          registry-type: ECR
+          oidc-iam-role: ${{ vars.oidc_staging_iam_role }}
 
   test-simple-no-repo-specified:
     if: cloudbees.api.url == 'https://api.saas-preprod.beescloud.com'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,10 @@
-#syntax=docker/dockerfile:1
-FROM golang:1.26.0-alpine3.22 AS build
-
-WORKDIR /work
-
-COPY go.mod* go.sum* ./
-
-RUN go mod download
-
-COPY . .
-
-RUN CGO_ENABLED=0 GOOS=linux go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o /usr/local/bin/checkout main.go
-
 FROM alpine:3.22
 
 RUN apk fix && \
     apk --no-cache --update add git git-lfs gpg less openssh patch && \
     git lfs install
 
-COPY --from=build /usr/local/bin/checkout /usr/local/bin/checkout
+COPY checkout /usr/local/bin/checkout
 
 WORKDIR /cloudbees/home
 


### PR DESCRIPTION
Replace the `kaniko@v1` + AWS/ECR login + `slsa-attestation` pipeline with a single `calculi-corp/cb-internal-shared-actions/build@v8` (services variant) call. Move go build into the workflow via `go-binary-build: true`. Dockerfile slimmed to runtime-only.

Generated by `/upgrade-shared-actions`.

Tracking: CBP-45084 (Upgrade Kaniko and V.x < V8 to shared actions V8: compliance, io).
