### PR TITLE
[CBP-45084] switch to build/action@v8 (action variant)

### DIFF
--- a/.cloudbees/workflows/workflow.yml
+++ b/.cloudbees/workflows/workflow.yml
@@ -30,7 +30,7 @@ jobs:
 
       - id: build
         name: Build, scan and push to ECR
-        uses: calculi-corp/cb-internal-shared-actions/build@v8
+        uses: calculi-corp/cb-internal-shared-actions/build/action@v8
         with:
           go-binary-build: "true"
           go-binary-name: checkout


### PR DESCRIPTION
Switch this repo from `calculi-corp/cb-internal-shared-actions/build@v8`
(services variant) to `build/action@v8` (action variant) — the variant
intended for cloudbees-io action repos.

Follows the pattern Kirk established in
[cloudbees-io/configure-oci-credentials#33](https://github.com/cloudbees-io/configure-oci-credentials/pull/33).
The producer side (clean `image:${gitsha}` tag prepended to the destination
list) shipped in
[calculi-corp/cb-internal-shared-actions#123](https://github.com/calculi-corp/cb-internal-shared-actions/pull/123).

### Edits applied

- `.cloudbees/workflows/workflow.yml`: `build@v8` → `build/action@v8`

### Edits NOT applied (already in good state)

- `permissions:` block already has `scm-token-org: read` (top-level + job-level).
- `.cloudbees/testing/action.yml` references `:preprod` tag, not `${{ action.scm.sha }}` —
  no rename needed.

Tracking: CBP-45084