### PR TITLE
[CBP-50927] Update build trigger to allow for paths in branch names

### DIFF
--- a/.cloudbees/workflows/workflow.yml
+++ b/.cloudbees/workflows/workflow.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - "*"
+      - "**"
 
 permissions:
   scm-token-own: read


### PR DESCRIPTION
## Summary

- Changes the push trigger branch pattern from `"*"` to `"**"` in `.cloudbees/workflows/workflow.yml`
- `"*"` only matches branch names with no slashes (e.g. `main`, `develop`), silently skipping branches like `feature/foo` or `fix/bar`
- `"**"` matches all branch names regardless of path depth

## Test plan

- [x] Verify the workflow triggers on a push to a branch with a slash in the name (e.g. `feature/test-branch`)
- [ ] Verify the workflow still triggers on a push to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)